### PR TITLE
fix: add await when using the async data

### DIFF
--- a/app/[userName]/page.tsx
+++ b/app/[userName]/page.tsx
@@ -19,7 +19,7 @@ export async function generateMetadata({
   return {
     title: params.userName + " | GH Link",
     icons: {
-      icon: user.avatar_url,
+      icon: await user.avatar_url,
     },
     openGraph: {
       type: "website",


### PR DESCRIPTION
The async data use in generateMeta() should add await.